### PR TITLE
Issue #19 - Test props of abstract class.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,5 +3,5 @@
 ossrhUsername=user
 ossrhPassword=pass
 
-version=1.2.4
+version=1.2.5-SNAPSHOT
 

--- a/src/main/java/net/digitaltsunami/pojot/GetterTestRunner.java
+++ b/src/main/java/net/digitaltsunami/pojot/GetterTestRunner.java
@@ -39,7 +39,8 @@ public class GetterTestRunner<T> extends AbstractTestRunner<T> {
         super(clazz, beanInfo);
         this.methodsUnderTest = methodsUnderTest;
         this.declaredFields =
-                Arrays.stream(clazz.getDeclaredFields())
+                TestAid.getDeclaredFieldsFromLineage(clazz).stream()
+                        .filter(field -> !field.isSynthetic())
                         .collect(toMap(field -> field.getName(), identity()));
     }
 

--- a/src/main/java/net/digitaltsunami/pojot/SetterTestRunner.java
+++ b/src/main/java/net/digitaltsunami/pojot/SetterTestRunner.java
@@ -49,7 +49,8 @@ public class SetterTestRunner<T> extends AbstractTestRunner<T> {
         super(clazz, beanInfo);
         this.methodsUnderTest = methodsUnderTest;
         this.declaredFields =
-                Arrays.stream(clazz.getDeclaredFields())
+                TestAid.getDeclaredFieldsFromLineage(clazz).stream()
+                        .filter(field -> !field.isSynthetic())
                         .collect(toMap(field -> field.getName(), identity()));
 
     }

--- a/src/test/java/net/digitaltsunami/pojot/AbstractClassTest.java
+++ b/src/test/java/net/digitaltsunami/pojot/AbstractClassTest.java
@@ -1,0 +1,62 @@
+package net.digitaltsunami.pojot;
+
+import net.digitaltsunami.pojot.testsubject.AbstractBaseClass;
+import net.digitaltsunami.pojot.testsubject.DerivedClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.beans.IntrospectionException;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Created by dhagberg on 5/7/16.
+ */
+public class AbstractClassTest {
+    @BeforeMethod
+    public void setup() {
+        AbstractBaseClass.getterInvoked = false;
+        AbstractBaseClass.setterInvoked = false;
+        DerivedClass.derivedGetterInvoked = false;
+        DerivedClass.derivedSetterInvoked = false;
+    }
+
+    @Test
+    public void validateGetters() throws IntrospectionException {
+        List<String> errors = new TestAid(DerivedClass.class, true)
+                .runGetterTests();
+        assertEquals(errors.size(), 0, "DerivedClass did not pass getter validation. " + errors );
+        assertTrue(AbstractBaseClass.getterInvoked, "Abstract getters were not tested.");
+        assertTrue(DerivedClass.derivedGetterInvoked, "Derived getters were not tested.");
+    }
+    @Test
+    public void validateSetters() throws IntrospectionException {
+        List<String> errors = new TestAid(DerivedClass.class, true)
+                .runSetterTests();
+        assertEquals( errors.size(), 0, "DerivedClass did not pass setter validation. " + errors );
+        assertTrue(AbstractBaseClass.setterInvoked, "Abstract setters were not tested.");
+        assertTrue(DerivedClass.derivedSetterInvoked, "Derived setters were not tested.");
+    }
+    @Test
+    public void validatePojo() throws IntrospectionException {
+        List<String> errors = new TestAid(DerivedClass.class, true)
+                .includeAllInEquals()
+                .includeInEquals("testDerivedClassString", "testDerivedClassLong")
+                .validate();
+        assertEquals(errors.size(), 0, "DerivedClass did not pass basic validation. " + errors);
+        assertTrue(AbstractBaseClass.getterInvoked, "Abstract getters were not tested.");
+        assertTrue(AbstractBaseClass.setterInvoked, "Abstract setters were not tested.");
+        assertTrue(DerivedClass.derivedGetterInvoked, "Derived getters were not tested.");
+        assertTrue(DerivedClass.derivedSetterInvoked, "Derived setters were not tested.");
+    }
+
+    @Test
+    public void validatePojoAbstractDisabled() throws IntrospectionException {
+        List<String> errors = new TestAid(DerivedClass.class)
+                .includeInEquals("testDerivedClassString", "testDerivedClassLong")
+                .validate();
+        assertEquals(errors.size(), 0, "DerivedClass did not pass basic validation. " + errors);
+    }
+}

--- a/src/test/java/net/digitaltsunami/pojot/testsubject/AbstractBaseClass.java
+++ b/src/test/java/net/digitaltsunami/pojot/testsubject/AbstractBaseClass.java
@@ -1,0 +1,52 @@
+package net.digitaltsunami.pojot.testsubject;
+
+/**
+ * Created by dhagberg on 5/7/16.
+ */
+public abstract class AbstractBaseClass {
+    private String testBaseClassString;
+    private int testBaseClassInt;
+    public static boolean getterInvoked;
+    public static boolean setterInvoked;
+
+    public abstract void testMethod();
+
+    public String getTestBaseClassString() {
+        getterInvoked = true;
+        return testBaseClassString;
+    }
+
+    public void setTestBaseClassString(String testBaseClassString) {
+        setterInvoked = true;
+        this.testBaseClassString = testBaseClassString;
+    }
+
+    public int getTestBaseClassInt() {
+        getterInvoked = true;
+        return testBaseClassInt;
+    }
+
+    public void setTestBaseClassInt(int testBaseClassInt) {
+        setterInvoked = true;
+        this.testBaseClassInt = testBaseClassInt;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        AbstractBaseClass that = (AbstractBaseClass) o;
+
+        if (getTestBaseClassInt() != that.getTestBaseClassInt()) return false;
+        return getTestBaseClassString() != null ? getTestBaseClassString().equals(that.getTestBaseClassString()) : that.getTestBaseClassString() == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getTestBaseClassString() != null ? getTestBaseClassString().hashCode() : 0;
+        result = 31 * result + getTestBaseClassInt();
+        return result;
+    }
+}

--- a/src/test/java/net/digitaltsunami/pojot/testsubject/DerivedClass.java
+++ b/src/test/java/net/digitaltsunami/pojot/testsubject/DerivedClass.java
@@ -1,0 +1,65 @@
+package net.digitaltsunami.pojot.testsubject;
+
+/**
+ * Created by dhagberg on 5/7/16.
+ */
+public class DerivedClass extends AbstractBaseClass {
+    private String testDerivedClassString;
+    private Long testDerivedClassLong;
+    public static boolean derivedGetterInvoked;
+    public static boolean derivedSetterInvoked;
+
+    @Override
+    public void testMethod() {
+    }
+
+    @Override
+    public String toString() {
+        return "DerivedClass{" +
+                "testDerivedClassString='" + testDerivedClassString + '\'' +
+                ", testDerivedClassLong=" + testDerivedClassLong +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        DerivedClass that = (DerivedClass) o;
+
+        if (testDerivedClassString != null ? !testDerivedClassString.equals(that.testDerivedClassString) : that.testDerivedClassString != null)
+            return false;
+        return testDerivedClassLong != null ? testDerivedClassLong.equals(that.testDerivedClassLong) : that.testDerivedClassLong == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (testDerivedClassString != null ? testDerivedClassString.hashCode() : 0);
+        result = 31 * result + (testDerivedClassLong != null ? testDerivedClassLong.hashCode() : 0);
+        return result;
+    }
+
+    public String getTestDerivedClassString() {
+        derivedGetterInvoked = true;
+        return testDerivedClassString;
+    }
+
+    public void setTestDerivedClassString(String testDerivedClassString) {
+        derivedSetterInvoked = true;
+        this.testDerivedClassString = testDerivedClassString;
+    }
+
+    public Long getTestDerivedClassLong() {
+        derivedGetterInvoked = true;
+        return testDerivedClassLong;
+    }
+
+    public void setTestDerivedClassLong(Long testDerivedClassLong) {
+        derivedSetterInvoked = true;
+        this.testDerivedClassLong = testDerivedClassLong;
+    }
+}


### PR DESCRIPTION
Added logic to include properties from abstract class when testing a
concrete implmenetation of the class. This is disabled by default
and must be enabled in the constructor.